### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/architecture/frontend/requirements.txt
+++ b/architecture/frontend/requirements.txt
@@ -12,7 +12,7 @@ spacy==3.7.5
 tiktoken==0.7.0
 tenacity==8.5.0
 PyMuPDF==1.24.7
-pyautogen==0.2.32
+ag2==0.2.32
 chromadb==0.5.4
 markdownify==0.13.1
 pypdf==4.3.0

--- a/architecture/ray_cluster/ray/entrypoint.sh
+++ b/architecture/ray_cluster/ray/entrypoint.sh
@@ -40,7 +40,7 @@ setup_conda_env() {
     pip install tiktoken==0.7.0
     pip install tenacity==8.5.0
     pip install PyMuPDF==1.24.7
-    pip install pyautogen==0.2.32
+    pip install ag2==0.2.32
     pip install chromadb==0.5.4
     pip install markdownify==0.13.1
     pip install pypdf==4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ spacy==3.7.5
 tiktoken==0.7.0
 tenacity==8.5.0
 PyMuPDF==1.24.7
-pyautogen==0.2.32
+ag2==0.2.32
 chromadb==0.5.4
 markdownify==0.13.1
 pypdf==4.3.0


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
